### PR TITLE
Fix daysFromToday() for month-long differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Returns a string for the given date, based on the user's "medium" format selecte
 
 Returns the number of days between today and the given date.
 
+If the date is more than a month away, return Infinity. (In this context of this plug-in, we only care about values within a week.)
+
 ## `getDayOfWeek (date: Date) : String`
 
 Returns the day of the week for the given date.

--- a/Scheduling.omnifocusjs/Resources/schedulingLib.js
+++ b/Scheduling.omnifocusjs/Resources/schedulingLib.js
@@ -36,7 +36,15 @@
   schedulingLib.daysFromToday = (date) => {
     const startOfToday = Calendar.current.startOfDay(new Date())
     const startOfDate = Calendar.current.startOfDay(date)
-    return Calendar.current.dateComponentsBetweenDates(startOfToday, startOfDate).day
+    const components = Calendar.current.dateComponentsBetweenDates(startOfToday, startOfDate)
+
+    // if the date is more than a month away, return Infinity
+    // in this context, we only care about values within a week
+    if (components.month > 0 || components.year > 0 || components.era > 0) {
+      return Infinity
+    }
+
+    return components.day
   }
 
   schedulingLib.getDayOfWeek = (date) => {


### PR DESCRIPTION
Fixes the `daysFromToday()` calculation for time differences of one month or more.

Previously, `daysFromToday()` called `dateComponentsBetweenDates()` but only looked at the `day` component—even if bigger components, like `month`, were already greater than zero. For example, this led to creating the tag “Tomorrow (2022-09-06)” when scheduling to September 6 (next month) because `daysFromToday()` only looked at 6-5—without considering the months of the two dates (September 6 and August 5).

I’m happy to discuss alternative solutions. Returning `Infinity` is not really elegant, but in the context of this plugin, we only really care about dates within the next seven days anyway.