### PR TITLE
Fix incorrect parsing of some dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ Returns the 'Scheduling' tag set in preferences. If no tag has been set, or the 
 
 Returns the date for a given tag. If no date can be parsed, returns null.
 
+## `getDateStringFromTag (tag: Tag) : String`
+
+Returns the date string for a given tag.
+
 ## `isToday (date: Date) : Boolean`
 
 Returns true if the given date is today; otherwise, returns false.

--- a/Scheduling.omnifocusjs/Resources/schedulingLib.js
+++ b/Scheduling.omnifocusjs/Resources/schedulingLib.js
@@ -113,8 +113,14 @@
 
   schedulingLib.getDate = (tag) => {
     const formatter = schedulingLib.getDateFormatter()
-    const date = formatter.dateFromString(tag.name)
+    const dateString = schedulingLib.getDateStringFromTag(tag)
+    const date = formatter.dateFromString(dateString)
     return date
+  }
+
+  schedulingLib.getDateStringFromTag = (tag) => {
+    const matches = tag.name.match(/ \((.*)\)$/)
+    return matches ? matches[1] : tag.name
   }
 
   schedulingLib.isToday = (date) => Calendar.current.startOfDay(date).getTime() === Calendar.current.startOfDay(new Date()).getTime()


### PR DESCRIPTION
Since the entire tag’s name is passed to `dateFromString()`, some tags which are prefixed with a day string may be parsed incorrectly. For example, “Tomorrow (01.09.2022)” is incorrectly parsed as 2022-08-01:

<img width="512" alt="Screenshot" src="https://user-images.githubusercontent.com/652793/187712108-5a0f1c7e-6b8d-4e8b-93cf-87ab834c8baa.png">

This pull request fixes that by first extracting the date string from the tag’s name.